### PR TITLE
Updated chart zoom

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,8 +162,8 @@ dependencies {
 
     coreLibraryDesugaring Libraries.desugarJdkLibs
 
-    debugApi "androidx.customview:customview:1.2.0-alpha01"
-    debugApi "androidx.customview:customview-poolingcontainer:1.0.0"
+    debugImplementation "androidx.customview:customview:1.2.0-alpha01"
+    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.17.0"
     implementation "com.google.accompanist:accompanist-swiperefresh:0.26.3-beta"
 }

--- a/common/ui/build.gradle
+++ b/common/ui/build.gradle
@@ -40,7 +40,11 @@ dependencies {
     androidTestImplementation ComposeLibraries.uiTestJunit4
     testImplementation ComposeLibraries.uiTestJunit4
     debugImplementation ComposeLibraries.uiTest
+    debugImplementation ComposeLibraries.uiTooling
 
     testImplementation Libraries.robolectric
+    // remove in the future
+    debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"
+    debugImplementation "androidx.customview:customview:1.2.0-alpha01"
 
 }

--- a/common/ui/src/main/java/com/simplekjl/ui/theme/components/Atoms.kt
+++ b/common/ui/src/main/java/com/simplekjl/ui/theme/components/Atoms.kt
@@ -220,7 +220,7 @@ fun LinearChartProgress(
     lineColor: Color,
 ) {
     val topLabel = stringResource(id = topLimitLabel)
-//    val bottomLabel = stringResource(id = bottomLimitLabel)
+    val bottomLabel = stringResource(id = bottomLimitLabel)
     AndroidView(
         modifier = modifier,
         factory = { context -> LineChart(context) },
@@ -230,9 +230,10 @@ fun LinearChartProgress(
             }
             val linearData = LineData(dataSet)
             linearChart.data = linearData
-            // grid properties
-            // https://stackoverflow.com/questions/31263097/mpandroidchart-hide-background-grid
-//            linearChart.xAxis.isEnabled = false
+            linearChart.setPinchZoom(false)
+            linearChart.setScaleEnabled(false)
+            linearChart.setTouchEnabled(true)
+            linearChart.isDoubleTapToZoomEnabled = false
             linearChart.axisRight.setDrawGridLines(false)
             linearChart.axisRight.isEnabled = false
             linearChart.xAxis.setDrawGridLines(false)


### PR DESCRIPTION
### resolves #17 

### Description:
Disable zoom in and avoid double click zoom while keeping properties to check the values in the chart 

<table>
  <tr>
    <th>Result</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/12452269/192222881-953158f2-70d1-4acc-9e3f-6725d67a27d4.png" width="300"></td>
  </tr>
</table>